### PR TITLE
Implement new trend analysis structures

### DIFF
--- a/Core/TrendAnalyzer.mqh
+++ b/Core/TrendAnalyzer.mqh
@@ -328,6 +328,37 @@ public:
         
         return (trendH4 == trendH1 && trendH1 == trendM15 && trendM15 == trendM5);
     }
+
+    //+------------------------------------------------------------------+
+    //| Analisar tendência com símbolo específico                       |
+    //+------------------------------------------------------------------+
+    bool AnalyzeTrend(string symbol, ENUM_TIMEFRAMES tf)
+    {
+        if(symbol != m_symbol)
+        {
+            CCoreUtils::LogWarning("Símbolo diferente do inicializado: " + symbol);
+        }
+
+        return (AnalyzeTrend(tf) != TREND_NEUTRAL);
+    }
+
+    //+------------------------------------------------------------------+
+    //| Obter resultado da análise                                      |
+    //+------------------------------------------------------------------+
+    TrendAnalysisResult GetAnalysisResult()
+    {
+        TrendAnalysisResult result;
+
+        result.trendDirection = m_lastTrendM15; // Usar M15 como padrão
+        result.trendStrength = GetTrendStrength(PERIOD_M15);
+        result.hasSequence = (result.trendDirection != TREND_NEUTRAL);
+        result.sequenceType = DetermineSequenceType();
+        result.sequenceStrength = result.trendStrength;
+        result.isValid = m_initialized;
+        result.lastUpdate = TimeCurrent();
+
+        return result;
+    }
     
     //+------------------------------------------------------------------+
     //| Obter símbolo atual                                             |
@@ -395,8 +426,25 @@ private:
             case PERIOD_M15: m_lastTrendM15 = trend; break;
             case PERIOD_M5:  m_lastTrendM5 = trend; break;
         }
-        
+
         m_lastUpdate = TimeCurrent();
+    }
+
+    //+------------------------------------------------------------------+
+    //| Determinar tipo de sequência                                    |
+    //+------------------------------------------------------------------+
+    ENUM_SEQUENCE_TYPE DetermineSequenceType()
+    {
+        if(m_lastTrendM15 == TREND_UP)
+        {
+            return SEQUENCE_ASCENDING_BOTTOMS;
+        }
+        else if(m_lastTrendM15 == TREND_DOWN)
+        {
+            return SEQUENCE_DESCENDING_TOPS;
+        }
+
+        return SEQUENCE_NONE;
     }
 };
 

--- a/SignalGeneration/ConfluenceAnalyzer.mqh
+++ b/SignalGeneration/ConfluenceAnalyzer.mqh
@@ -205,16 +205,12 @@ private:
     //+------------------------------------------------------------------+
     void InitializeConfluenceResult(ConfluenceResult &result)
     {
-        result.symbol = "";
-        result.timestamp = 0;
         result.confluenceScore = 0;
         result.bullishFactors = 0;
         result.bearishFactors = 0;
         result.neutralFactors = 0;
-        result.totalFactors = 0;
-        result.strongestFactor = "";
-        result.weakestFactor = "";
         result.isValid = false;
+        result.lastUpdate = 0;
     }
     
     //+------------------------------------------------------------------+

--- a/SignalGeneration/SignalGenerator.mqh
+++ b/SignalGeneration/SignalGenerator.mqh
@@ -29,11 +29,11 @@ private:
     CConfluenceAnalyzer* m_confluence;       // Analisador de confluência
     
     // Sinais gerados
-    TradingSignal        m_currentSignal;    // Sinal atual
-    TradingSignal        m_lastSignal;       // Último sinal
+    TradeSignal          m_currentSignal;    // Sinal atual
+    TradeSignal          m_lastSignal;       // Último sinal
     
     // Histórico de sinais
-    TradingSignal        m_signalHistory[];  // Histórico
+    TradeSignal          m_signalHistory[];  // Histórico
     int                  m_historySize;      // Tamanho do histórico
     
     // Estado do gerador
@@ -194,12 +194,12 @@ public:
     //+------------------------------------------------------------------+
     //| Obter sinal atual                                              |
     //+------------------------------------------------------------------+
-    TradingSignal GetCurrentSignal() const { return m_currentSignal; }
+    TradeSignal GetCurrentSignal() const { return m_currentSignal; }
     
     //+------------------------------------------------------------------+
     //| Obter último sinal                                             |
     //+------------------------------------------------------------------+
-    TradingSignal GetLastSignal() const { return m_lastSignal; }
+    TradeSignal GetLastSignal() const { return m_lastSignal; }
     
     //+------------------------------------------------------------------+
     //| Verificar se há sinal válido                                   |
@@ -244,7 +244,7 @@ public:
     //+------------------------------------------------------------------+
     //| Obter histórico de sinais                                      |
     //+------------------------------------------------------------------+
-    int GetSignalHistory(TradingSignal &history[])
+    int GetSignalHistory(TradeSignal &history[])
     {
         if(m_historySize == 0) return 0;
         
@@ -267,7 +267,7 @@ private:
     //+------------------------------------------------------------------+
     //| Inicializar estrutura de sinal                                 |
     //+------------------------------------------------------------------+
-    void InitializeSignal(TradingSignal &signal)
+    void InitializeSignal(TradeSignal &signal)
     {
         signal.type = SIGNAL_NONE;
         signal.symbol = "";
@@ -561,7 +561,7 @@ private:
     //+------------------------------------------------------------------+
     //| Adicionar sinal ao histórico                                   |
     //+------------------------------------------------------------------+
-    void AddToHistory(const TradingSignal &signal)
+    void AddToHistory(const TradeSignal &signal)
     {
         if(m_historySize >= MAX_SIGNAL_HISTORY)
         {

--- a/TimeframeAnalysis/TimeframeSequencer.mqh
+++ b/TimeframeAnalysis/TimeframeSequencer.mqh
@@ -235,12 +235,11 @@ private:
     void InitializeSequenceResult(SequenceAnalysisResult &result)
     {
         result.timeframe = PERIOD_CURRENT;
-        result.stepNumber = 0;
-        result.stepPassed = false;
-        result.stepStrength = 0;
-        result.trendDirection = TREND_NEUTRAL;
-        result.failureReason = "";
+        result.direction = TREND_NEUTRAL;
+        result.strength = 0;
         result.isValid = false;
+        result.allowsEntry = false;
+        result.timestamp = 0;
     }
     
     //+------------------------------------------------------------------+

--- a/TrendAnalyzerConfig.mqh
+++ b/TrendAnalyzerConfig.mqh
@@ -132,5 +132,14 @@
 #define UPDATE_FREQUENCY_MS     1000     // Frequência de atualização (ms)
 #define CACHE_VALIDITY_SECONDS  60       // Validade do cache (segundos)
 
+//+------------------------------------------------------------------+
+//| Configurações de Sinal e Confluência                            |
+//+------------------------------------------------------------------+
+#define MAX_SIGNAL_HISTORY      100      // Máximo de sinais no histórico
+#define SIGNAL_MIN_INTERVAL     300      // Intervalo mínimo entre sinais (segundos)
+#define MIN_SIGNAL_STRENGTH     70.0     // Força mínima do sinal (%)
+#define MIN_CONFLUENCE_SCORE    60.0     // Score mínimo de confluência (%)
+#define MAX_CONFLUENCE_FACTORS  20       // Máximo de fatores de confluência
+
 #endif // TREND_ANALYZER_CONFIG_H
 

--- a/TrendAnalyzerEA.mq5
+++ b/TrendAnalyzerEA.mq5
@@ -11,7 +11,11 @@
 #property version   "1.0"
 #property description "Expert Advisor para análise de tendência WINM25"
 
-// Incluir todos os módulos necessários
+// Incluir bibliotecas padrão PRIMEIRO
+#include <Trade\Trade.mqh>
+#include <Object.mqh>
+
+// Depois incluir módulos locais
 #include "TrendAnalyzerEnums.mqh"
 #include "TrendAnalyzerConfig.mqh"
 #include "Core/CoreUtils.mqh"
@@ -95,8 +99,8 @@ double               g_dailyProfit = 0;               // Lucro do dia
 double               g_dailyLoss = 0;                 // Perda do dia
 
 // Controle de sinais
-TradingSignal        g_currentSignal;                 // Sinal atual
-TradingSignal        g_lastSignal;                    // Último sinal
+TradeSignal          g_currentSignal;                 // Sinal atual
+TradeSignal          g_lastSignal;                    // Último sinal
 bool                 g_signalActive = false;          // Sinal ativo
 
 // Estatísticas
@@ -542,7 +546,7 @@ void CheckForTradingSignals()
     }
     
     // Obter sinal atual
-    TradingSignal signal = g_signalGenerator.GetCurrentSignal();
+    TradeSignal signal = g_signalGenerator.GetCurrentSignal();
     
     // Validar sinal
     if(!ValidateSignal(signal))
@@ -566,7 +570,7 @@ void CheckForTradingSignals()
 //+------------------------------------------------------------------+
 //| Validar sinal de trading                                        |
 //+------------------------------------------------------------------+
-bool ValidateSignal(const TradingSignal &signal)
+bool ValidateSignal(const TradeSignal &signal)
 {
     // Verificar se sinal é válido
     if(!signal.isValid || signal.type == SIGNAL_NONE)
@@ -629,7 +633,7 @@ bool ValidateSignal(const TradingSignal &signal)
 //+------------------------------------------------------------------+
 //| Executar sinal de trading                                       |
 //+------------------------------------------------------------------+
-void ExecuteSignal(const TradingSignal &signal)
+void ExecuteSignal(const TradeSignal &signal)
 {
     if(g_tradeExecutor == NULL)
     {
@@ -724,7 +728,7 @@ void PrintFinalStatistics()
 //+------------------------------------------------------------------+
 //| Log de sinal                                                    |
 //+------------------------------------------------------------------+
-void LogSignal(const TradingSignal &signal)
+void LogSignal(const TradeSignal &signal)
 {
     string logMessage = "SINAL: " + EnumToString(signal.type) + 
                        " | Força: " + DoubleToString(signal.strength, 1) + "%" +

--- a/TrendAnalyzerEnums.mqh
+++ b/TrendAnalyzerEnums.mqh
@@ -182,5 +182,95 @@ struct VolumeData
    bool     isConfirming;   // Se o volume confirma o movimento
 };
 
+//+------------------------------------------------------------------+
+//| Estrutura de Resultado de Análise de Tendência                  |
+//+------------------------------------------------------------------+
+struct TrendAnalysisResult
+{
+    ENUM_TREND_DIRECTION trendDirection;    // Direção da tendência
+    double               trendStrength;     // Força da tendência (0-100)
+    bool                 hasSequence;       // Se tem sequência válida
+    ENUM_SEQUENCE_TYPE   sequenceType;      // Tipo da sequência
+    double               sequenceStrength;  // Força da sequência (0-100)
+    bool                 isValid;           // Se o resultado é válido
+    datetime             lastUpdate;        // Última atualização
+};
+
+//+------------------------------------------------------------------+
+//| Estrutura de Análise Multi-Timeframe                            |
+//+------------------------------------------------------------------+
+struct MultiTimeframeAnalysis
+{
+    ENUM_TREND_DIRECTION overallDirection;  // Direção geral
+    double               overallStrength;   // Força geral (0-100)
+    ENUM_TIMEFRAME_ALIGNMENT alignment;     // Alinhamento dos timeframes
+    ENUM_TIMEFRAMES      dominantTimeframe; // Timeframe dominante
+    double               confluenceScore;   // Score de confluência (0-100)
+    bool                 isValid;           // Se a análise é válida
+    datetime             lastUpdate;        // Última atualização
+};
+
+//+------------------------------------------------------------------+
+//| Estrutura de Resultado de Confluência                           |
+//+------------------------------------------------------------------+
+struct ConfluenceResult
+{
+    double   confluenceScore;   // Score total de confluência (0-100)
+    int      bullishFactors;    // Número de fatores bullish
+    int      bearishFactors;    // Número de fatores bearish
+    int      neutralFactors;    // Número de fatores neutros
+    bool     isValid;           // Se o resultado é válido
+    datetime lastUpdate;        // Última atualização
+};
+
+//+------------------------------------------------------------------+
+//| Estrutura de Fator de Confluência                               |
+//+------------------------------------------------------------------+
+struct ConfluenceFactor
+{
+    string           factorName;   // Nome do fator
+    ENUM_SIGNAL_TYPE direction;    // Direção do fator
+    double           weight;       // Peso do fator (0-1)
+    double           confidence;   // Confiança do fator (0-100)
+    bool             isActive;     // Se o fator está ativo
+};
+
+//+------------------------------------------------------------------+
+//| Estrutura de Resultado de Análise de Sequência                  |
+//+------------------------------------------------------------------+
+struct SequenceAnalysisResult
+{
+    ENUM_TIMEFRAMES      timeframe;    // Timeframe analisado
+    ENUM_TREND_DIRECTION direction;    // Direção identificada
+    double               strength;     // Força da sequência (0-100)
+    bool                 isValid;      // Se o resultado é válido
+    bool                 allowsEntry;  // Se permite entrada
+    datetime             timestamp;    // Timestamp da análise
+};
+
+//+------------------------------------------------------------------+
+//| Enumeração de Alinhamento de Timeframes                         |
+//+------------------------------------------------------------------+
+enum ENUM_TIMEFRAME_ALIGNMENT
+{
+    TF_BULLISH_STRONG,    // Alinhamento bullish forte (3+ timeframes)
+    TF_BULLISH_WEAK,      // Alinhamento bullish fraco (2 timeframes)
+    TF_BEARISH_STRONG,    // Alinhamento bearish forte (3+ timeframes)
+    TF_BEARISH_WEAK,      // Alinhamento bearish fraco (2 timeframes)
+    TF_NEUTRAL            // Sem alinhamento claro
+};
+
+//+------------------------------------------------------------------+
+//| Enumeração de Tipo de Sequência                                 |
+//+------------------------------------------------------------------+
+enum ENUM_SEQUENCE_TYPE
+{
+    SEQUENCE_NONE,                // Nenhuma sequência identificada
+    SEQUENCE_ASCENDING_TOPS,      // Topos ascendentes
+    SEQUENCE_DESCENDING_TOPS,     // Topos descendentes
+    SEQUENCE_ASCENDING_BOTTOMS,   // Fundos ascendentes
+    SEQUENCE_DESCENDING_BOTTOMS   // Fundos descendentes
+};
+
 #endif // TREND_ANALYZER_ENUMS_H
 


### PR DESCRIPTION
## Summary
- add trend analysis result structs and enums
- expand config with signal/confluence limits
- fix include order and signal types in EA
- expose analysis helpers in `CTrendAnalyzer`
- align SignalGenerator and other modules with `TradeSignal`

## Testing
- `mql5compiler TrendAnalyzerEA.mq5` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856a9226bac83209c3495ba79463959