### PR TITLE
Fix missing CObject include

### DIFF
--- a/Core/TrendAnalyzer.mqh
+++ b/Core/TrendAnalyzer.mqh
@@ -8,6 +8,7 @@
 #ifndef TREND_ANALYZER_H
 #define TREND_ANALYZER_H
 
+#include <Object.mqh>
 #include "../TrendAnalyzerEnums.mqh"
 #include "../TrendAnalyzerConfig.mqh"
 

--- a/TimeframeAnalysis/MultiTimeframe.mqh
+++ b/TimeframeAnalysis/MultiTimeframe.mqh
@@ -8,6 +8,7 @@
 #ifndef MULTI_TIMEFRAME_H
 #define MULTI_TIMEFRAME_H
 
+#include <Object.mqh>
 #include "../TrendAnalyzerEnums.mqh"
 #include "../TrendAnalyzerConfig.mqh"
 #include "../Core/CoreUtils.mqh"


### PR DESCRIPTION
## Summary
- include `<Object.mqh>` for TrendAnalyzer and MultiTimeframe classes

## Testing
- `wine --version` *(fails: command not found)*
- `mql5compiler` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856ea2907bc8320b4c8107083ccb895