### PR TITLE
Define missing constants for confluence analyzer

### DIFF
--- a/TrendAnalyzerConfig.mqh
+++ b/TrendAnalyzerConfig.mqh
@@ -102,6 +102,12 @@
 #define HISTORY_BARS_PATTERN    50       // Barras para padrões
 
 //+------------------------------------------------------------------+
+//| Limites de armazenamento                                         |
+//+------------------------------------------------------------------+
+#define MAX_CONFLUENCE_FACTORS  64       // Máximo de fatores de confluência
+#define MAX_SIGNAL_HISTORY      50       // Tamanho do histórico de sinais
+
+//+------------------------------------------------------------------+
 //| Configurações de Debug e Log                                    |
 //+------------------------------------------------------------------+
 #define DEBUG_MODE              true     // Modo debug ativo


### PR DESCRIPTION
## Summary
- add `MAX_CONFLUENCE_FACTORS` and `MAX_SIGNAL_HISTORY` definitions in `TrendAnalyzerConfig.mqh`

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6856f0f5a344832082100f0e878c938c