### PR TITLE
Fix compilation by including Object.mqh

### DIFF
--- a/Indicators/BollingerBands.mqh
+++ b/Indicators/BollingerBands.mqh
@@ -8,6 +8,7 @@
 #ifndef BOLLINGER_BANDS_H
 #define BOLLINGER_BANDS_H
 
+#include <Object.mqh>
 #include "../TrendAnalyzerEnums.mqh"
 #include "../TrendAnalyzerConfig.mqh"
 #include "../Core/CoreUtils.mqh"

--- a/Indicators/Fibonacci.mqh
+++ b/Indicators/Fibonacci.mqh
@@ -8,6 +8,7 @@
 #ifndef FIBONACCI_H
 #define FIBONACCI_H
 
+#include <Object.mqh>
 #include "../TrendAnalyzerEnums.mqh"
 #include "../TrendAnalyzerConfig.mqh"
 #include "../Core/CoreUtils.mqh"

--- a/Indicators/MovingAverages.mqh
+++ b/Indicators/MovingAverages.mqh
@@ -8,6 +8,7 @@
 #ifndef MOVING_AVERAGES_H
 #define MOVING_AVERAGES_H
 
+#include <Object.mqh>
 #include "../TrendAnalyzerEnums.mqh"
 #include "../TrendAnalyzerConfig.mqh"
 #include "../Core/CoreUtils.mqh"

--- a/Indicators/VWAP.mqh
+++ b/Indicators/VWAP.mqh
@@ -8,6 +8,7 @@
 #ifndef VWAP_H
 #define VWAP_H
 
+#include <Object.mqh>
 #include "../TrendAnalyzerEnums.mqh"
 #include "../TrendAnalyzerConfig.mqh"
 #include "../Core/CoreUtils.mqh"

--- a/Indicators/VolumeAnalyzer.mqh
+++ b/Indicators/VolumeAnalyzer.mqh
@@ -8,6 +8,7 @@
 #ifndef VOLUME_ANALYZER_H
 #define VOLUME_ANALYZER_H
 
+#include <Object.mqh>
 #include "../TrendAnalyzerEnums.mqh"
 #include "../TrendAnalyzerConfig.mqh"
 #include "../Core/CoreUtils.mqh"

--- a/PriceAction/AdvancedPatterns.mqh
+++ b/PriceAction/AdvancedPatterns.mqh
@@ -8,6 +8,7 @@
 #ifndef ADVANCED_PATTERNS_H
 #define ADVANCED_PATTERNS_H
 
+#include <Object.mqh>
 #include "../TrendAnalyzerEnums.mqh"
 #include "../TrendAnalyzerConfig.mqh"
 #include "../Core/CoreUtils.mqh"

--- a/PriceAction/Channels.mqh
+++ b/PriceAction/Channels.mqh
@@ -8,6 +8,7 @@
 #ifndef CHANNELS_H
 #define CHANNELS_H
 
+#include <Object.mqh>
 #include "../TrendAnalyzerEnums.mqh"
 #include "../TrendAnalyzerConfig.mqh"
 #include "../Core/CoreUtils.mqh"

--- a/PriceAction/SupportResistance.mqh
+++ b/PriceAction/SupportResistance.mqh
@@ -8,6 +8,7 @@
 #ifndef SUPPORT_RESISTANCE_H
 #define SUPPORT_RESISTANCE_H
 
+#include <Object.mqh>
 #include "../TrendAnalyzerEnums.mqh"
 #include "../TrendAnalyzerConfig.mqh"
 #include "../Core/CoreUtils.mqh"

--- a/PriceAction/TrendLines.mqh
+++ b/PriceAction/TrendLines.mqh
@@ -8,6 +8,7 @@
 #ifndef TREND_LINES_H
 #define TREND_LINES_H
 
+#include <Object.mqh>
 #include "../TrendAnalyzerEnums.mqh"
 #include "../TrendAnalyzerConfig.mqh"
 #include "../Core/CoreUtils.mqh"

--- a/SignalGeneration/ConfluenceAnalyzer.mqh
+++ b/SignalGeneration/ConfluenceAnalyzer.mqh
@@ -8,6 +8,7 @@
 #ifndef CONFLUENCE_ANALYZER_H
 #define CONFLUENCE_ANALYZER_H
 
+#include <Object.mqh>
 #include "../TrendAnalyzerEnums.mqh"
 #include "../TrendAnalyzerConfig.mqh"
 #include "../Core/CoreUtils.mqh"

--- a/SignalGeneration/SignalGenerator.mqh
+++ b/SignalGeneration/SignalGenerator.mqh
@@ -8,6 +8,7 @@
 #ifndef SIGNAL_GENERATOR_H
 #define SIGNAL_GENERATOR_H
 
+#include <Object.mqh>
 #include "../TrendAnalyzerEnums.mqh"
 #include "../TrendAnalyzerConfig.mqh"
 #include "../Core/CoreUtils.mqh"

--- a/TimeframeAnalysis/TimeframeSequencer.mqh
+++ b/TimeframeAnalysis/TimeframeSequencer.mqh
@@ -8,6 +8,7 @@
 #ifndef TIMEFRAME_SEQUENCER_H
 #define TIMEFRAME_SEQUENCER_H
 
+#include <Object.mqh>
 #include "../TrendAnalyzerEnums.mqh"
 #include "../TrendAnalyzerConfig.mqh"
 #include "../Core/CoreUtils.mqh"

--- a/TradeExecution/TradeExecutor.mqh
+++ b/TradeExecution/TradeExecutor.mqh
@@ -8,6 +8,7 @@
 #ifndef TRADE_EXECUTOR_H
 #define TRADE_EXECUTOR_H
 
+#include <Object.mqh>
 #include <Trade/Trade.mqh>
 #include "../TrendAnalyzerEnums.mqh"
 #include "../TrendAnalyzerConfig.mqh"


### PR DESCRIPTION
## Summary
- fix CObject declaration errors by including `<Object.mqh>` in all modules that define classes inheriting from `CObject`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6856f93477648320b34426507e58b2e7