### PR TITLE
Fix invalid array access in IdentifyPivotPoints

### DIFF
--- a/PriceAction/TrendLines.mqh
+++ b/PriceAction/TrendLines.mqh
@@ -342,7 +342,7 @@ private:
     {
         ArrayFree(m_pivots);
         
-        int arraySize = ArraySize(findHighs ? m_high : m_low);
+        int arraySize = findHighs ? ArraySize(m_high) : ArraySize(m_low);
         if(arraySize < 10) return false;
         
         // Procurar pontos de pivô


### PR DESCRIPTION
## Summary
- fix usage of `ArraySize` in `IdentifyPivotPoints`

## Testing
- `npm test` *(fails: cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685700169e6c8320bcc77d0480b3615a