### PR TITLE
Fix compile issues in signal generation modules

### DIFF
--- a/PriceAction/SupportResistance.mqh
+++ b/PriceAction/SupportResistance.mqh
@@ -187,8 +187,52 @@ public:
                 }
             }
         }
-        
+
         return false;
+    }
+
+    //+------------------------------------------------------------------+
+    //| Obter suportes próximos                                         |
+    //+------------------------------------------------------------------+
+    int GetNearbySupports(double currentPrice, double tolerance, double &levels[])
+    {
+        ArrayFree(levels);
+        int count = 0;
+
+        for(int i = 0; i < ArraySize(m_levels); i++)
+        {
+            if(m_levels[i].isSupport &&
+               CCoreUtils::IsPriceWithinTolerance(currentPrice, m_levels[i].price, tolerance, m_symbol))
+            {
+                ArrayResize(levels, count + 1);
+                levels[count] = m_levels[i].price;
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    //+------------------------------------------------------------------+
+    //| Obter resistências próximas                                    |
+    //+------------------------------------------------------------------+
+    int GetNearbyResistances(double currentPrice, double tolerance, double &levels[])
+    {
+        ArrayFree(levels);
+        int count = 0;
+
+        for(int i = 0; i < ArraySize(m_levels); i++)
+        {
+            if(!m_levels[i].isSupport &&
+               CCoreUtils::IsPriceWithinTolerance(currentPrice, m_levels[i].price, tolerance, m_symbol))
+            {
+                ArrayResize(levels, count + 1);
+                levels[count] = m_levels[i].price;
+                count++;
+            }
+        }
+
+        return count;
     }
     
     //+------------------------------------------------------------------+

--- a/SignalGeneration/ConfluenceAnalyzer.mqh
+++ b/SignalGeneration/ConfluenceAnalyzer.mqh
@@ -117,7 +117,7 @@ public:
         
         allInitialized &= m_trendLines.Initialize(symbol);
         allInitialized &= m_supRes.Initialize(symbol);
-        allInitialized &= m_channels.Initialize(symbol);
+        allInitialized &= m_channels.Initialize(symbol, m_trendLines);
         allInitialized &= m_movingAverages.Initialize(symbol);
         allInitialized &= m_vwap.Initialize(symbol);
         allInitialized &= m_bollingerBands.Initialize(symbol);
@@ -241,9 +241,9 @@ private:
     void AnalyzeTrendLinesConfluence(double currentPrice)
     {
         // Analisar LTA (Linha de Tendência de Alta)
-        if(m_trendLines.HasValidLTA())
+        if(m_trendLines.IsLTAValid())
         {
-            double ltaLevel = m_trendLines.GetCurrentLTALevel();
+            double ltaLevel = m_trendLines.GetCurrentLTALevel(TimeCurrent());
             bool nearLTA = m_trendLines.IsPriceNearLTA(currentPrice, TOLERANCE_TRENDLINE);
             
             if(nearLTA)
@@ -262,9 +262,9 @@ private:
         }
         
         // Analisar LTB (Linha de Tendência de Baixa)
-        if(m_trendLines.HasValidLTB())
+        if(m_trendLines.IsLTBValid())
         {
-            double ltbLevel = m_trendLines.GetCurrentLTBLevel();
+            double ltbLevel = m_trendLines.GetCurrentLTBLevel(TimeCurrent());
             bool nearLTB = m_trendLines.IsPriceNearLTB(currentPrice, TOLERANCE_TRENDLINE);
             
             if(nearLTB)

--- a/SignalGeneration/SignalGenerator.mqh
+++ b/SignalGeneration/SignalGenerator.mqh
@@ -478,7 +478,23 @@ private:
     void CalculateStopLossAndTakeProfit(ENUM_TREND_DIRECTION direction,
                                        const ConfluenceResult &confluence)
     {
-        double atr = CCoreUtils::CalculateATR(NULL, NULL, NULL, 20, 20); // Simplificado
+        double atr = 0;
+        double high[], low[], close[];
+        ArraySetAsSeries(high, true);
+        ArraySetAsSeries(low, true);
+        ArraySetAsSeries(close, true);
+
+        if(CopyHigh(m_symbol, PERIOD_CURRENT, 0, 21, high) < 0 ||
+           CopyLow(m_symbol, PERIOD_CURRENT, 0, 21, low) < 0 ||
+           CopyClose(m_symbol, PERIOD_CURRENT, 0, 21, close) < 0)
+        {
+            atr = 0;
+        }
+        else
+        {
+            atr = CCoreUtils::CalculateATR(high, low, close, 20);
+        }
+
         if(atr <= 0) atr = 100; // Valor padrão em pontos
         
         double stopDistance = atr * STOP_LOSS_ATR_MULTIPLIER;

--- a/TrendAnalyzerConfig.mqh
+++ b/TrendAnalyzerConfig.mqh
@@ -127,6 +127,7 @@
 #define HISTORY_BARS_TRENDLINE  100      // Barras para linha de tendência
 #define HISTORY_BARS_SR         200      // Barras para suporte/resistência
 #define HISTORY_BARS_PATTERN    50       // Barras para padrões
+#define HISTORY_BARS_FIBONACCI  200      // Barras para análise de Fibonacci
 
 //+------------------------------------------------------------------+
 //| Limites de armazenamento                                         |

--- a/TrendAnalyzerTest.mq5
+++ b/TrendAnalyzerTest.mq5
@@ -199,8 +199,8 @@ bool TestPriceActionModule()
     
     if(trendLines.Initialize(TestSymbol))
     {
-        bool hasLTA = trendLines.HasValidLTA();
-        bool hasLTB = trendLines.HasValidLTB();
+        bool hasLTA = trendLines.IsLTAValid();
+        bool hasLTB = trendLines.IsLTBValid();
         Print("TrendLines: OK - LTA: ", (hasLTA ? "SIM" : "NÃO"), ", LTB: ", (hasLTB ? "SIM" : "NÃO"));
     }
     else


### PR DESCRIPTION
## Summary
- add missing `HISTORY_BARS_FIBONACCI` constant
- connect `Channels` to `TrendLines` during initialization
- update trend line checks and level retrieval calls
- implement retrieval of nearby support/resistance levels
- compute ATR using recent market data
- adjust tests for new API names

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685716d5c94c8320af35fbb5aa2930df