### PR TITLE
Fix position type handling in TradeExecutor

### DIFF
--- a/TradeExecution/TradeExecutor.mqh
+++ b/TradeExecution/TradeExecutor.mqh
@@ -515,7 +515,8 @@ private:
         }
         
         double currentPrice = SymbolInfoDouble(m_symbol, SYMBOL_BID);
-        double positionType = PositionGetInteger(POSITION_TYPE);
+        ENUM_POSITION_TYPE positionType =
+            (ENUM_POSITION_TYPE)PositionGetInteger(POSITION_TYPE);
         double openPrice = PositionGetDouble(POSITION_PRICE_OPEN);
         double currentSL = PositionGetDouble(POSITION_SL);
         
@@ -569,7 +570,8 @@ private:
         double openPrice = PositionGetDouble(POSITION_PRICE_OPEN);
         double currentPrice = SymbolInfoDouble(m_symbol, SYMBOL_BID);
         double takeProfit = PositionGetDouble(POSITION_TP);
-        double positionType = PositionGetInteger(POSITION_TYPE);
+        ENUM_POSITION_TYPE positionType =
+            (ENUM_POSITION_TYPE)PositionGetInteger(POSITION_TYPE);
         
         bool shouldPartialClose = false;
         


### PR DESCRIPTION
## Summary
- fix datatype for position type in trailing stop logic
- fix datatype for position type in partial close logic

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68571ecaed388320807920b8f3fd71d3