### PR TITLE
Fix double trend analysis

### DIFF
--- a/Core/CoreTest.mq5
+++ b/Core/CoreTest.mq5
@@ -146,7 +146,7 @@ bool TestTrendAnalysis()
         }
         
         // Testar força da tendência
-        double strength = analyzer.GetTrendStrength(timeframes[i]);
+        double strength = analyzer.CalculateTrendStrength(timeframes[i], trend);
         if(strength < 0 || strength > 100)
         {
             Print("FALHA: Força da tendência fora do range (0-100): ", strength);

--- a/Core/TrendAnalyzer.mqh
+++ b/Core/TrendAnalyzer.mqh
@@ -259,27 +259,26 @@ public:
     }
     
     //+------------------------------------------------------------------+
-    //| Obter força da tendência (0-100)                                |
+    //| Calcular força da tendência usando direção fornecida (0-100)    |
     //+------------------------------------------------------------------+
-    double GetTrendStrength(ENUM_TIMEFRAMES tf)
+    double CalculateTrendStrength(ENUM_TIMEFRAMES tf, ENUM_TREND_DIRECTION currentTrend)
     {
-        if(!GetHistoricalData(tf, 50))
-            return 0;
-        
-        double strength = 0;
-        int consecutiveBars = 0;
-        ENUM_TREND_DIRECTION currentTrend = AnalyzeTrend(tf);
-        
         if(currentTrend == TREND_NEUTRAL)
             return 0;
-        
+
+        if(!GetHistoricalData(tf, 50))
+            return 0;
+
+        double strength = 0;
+        int consecutiveBars = 0;
+
         // Contar barras consecutivas na direção da tendência
         for(int i = 1; i < MathMin(20, ArraySize(m_close)); i++)
         {
             bool bullishBar = (m_close[i-1] > m_close[i]);
             bool bearishBar = (m_close[i-1] < m_close[i]);
-            
-            if((currentTrend == TREND_UP && bullishBar) || 
+
+            if((currentTrend == TREND_UP && bullishBar) ||
                (currentTrend == TREND_DOWN && bearishBar))
             {
                 consecutiveBars++;
@@ -289,10 +288,10 @@ public:
                 break;
             }
         }
-        
+
         // Calcular força baseada em barras consecutivas e amplitude
         strength = MathMin(100, consecutiveBars * 5); // Máximo 100%
-        
+
         // Ajustar baseado na amplitude do movimento
         if(ArraySize(m_close) >= 20)
         {
@@ -300,15 +299,24 @@ public:
             double lowestLow = m_low[ArrayMinimum(m_low, 0, 20)];
             double range = highestHigh - lowestLow;
             double currentRange = MathAbs(m_close[0] - m_close[19]);
-            
+
             if(range > 0)
             {
                 double rangeRatio = currentRange / range;
                 strength *= rangeRatio;
             }
         }
-        
+
         return MathMin(100, MathMax(0, strength));
+    }
+
+    //+------------------------------------------------------------------+
+    //| Obter força da tendência (0-100)                                |
+    //+------------------------------------------------------------------+
+    double GetTrendStrength(ENUM_TIMEFRAMES tf)
+    {
+        ENUM_TREND_DIRECTION trend = AnalyzeTrend(tf);
+        return CalculateTrendStrength(tf, trend);
     }
     
     //+------------------------------------------------------------------+

--- a/TimeframeAnalysis/MultiTimeframe.mqh
+++ b/TimeframeAnalysis/MultiTimeframe.mqh
@@ -375,7 +375,7 @@ private:
 
         // Preencher resultado utilizando as informações disponíveis no analisador
         result.trendDirection   = direction;
-        result.trendStrength    = analyzer.GetTrendStrength(tf);
+        result.trendStrength    = analyzer.CalculateTrendStrength(tf, direction);
         result.hasSequence      = false;
         result.sequenceType     = SEQUENCE_NONE;
         result.sequenceStrength = 0;

--- a/TrendAnalyzerTest.mq5
+++ b/TrendAnalyzerTest.mq5
@@ -161,7 +161,7 @@ bool TestCoreModule()
 
     TrendAnalysisResult result;
     result.trendDirection   = trend;
-    result.trendStrength    = analyzer.GetTrendStrength(PERIOD_H1);
+    result.trendStrength    = analyzer.CalculateTrendStrength(PERIOD_H1, trend);
     result.hasSequence      = false;
     result.sequenceType     = SEQUENCE_NONE;
     result.sequenceStrength = 0;


### PR DESCRIPTION
## Summary
- prevent duplicate AnalyzeTrend calls
- compute trend strength using already determined direction

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685758c7fc3c83209913883eec35d8c4