### PR TITLE
Fix trade stats and signal rules

### DIFF
--- a/Core/TrendAnalyzer.mqh
+++ b/Core/TrendAnalyzer.mqh
@@ -275,8 +275,8 @@ public:
         // Contar barras consecutivas na direção da tendência
         for(int i = 1; i < MathMin(20, ArraySize(m_close)); i++)
         {
-            bool bullishBar = (m_close[i-1] > m_close[i]);
-            bool bearishBar = (m_close[i-1] < m_close[i]);
+            bool bullishBar = (m_close[i] > m_close[i-1]);
+            bool bearishBar = (m_close[i] < m_close[i-1]);
 
             if((currentTrend == TREND_UP && bullishBar) ||
                (currentTrend == TREND_DOWN && bearishBar))

--- a/SignalGeneration/SignalGenerator.mqh
+++ b/SignalGeneration/SignalGenerator.mqh
@@ -16,6 +16,8 @@
 #include "../TimeframeAnalysis/TimeframeSequencer.mqh"
 #include "ConfluenceAnalyzer.mqh"
 
+extern bool Signal_OnlyLiquidityHours;
+
 //+------------------------------------------------------------------+
 //| Classe Geradora de Sinais                                       |
 //+------------------------------------------------------------------+
@@ -321,8 +323,8 @@ private:
             return false;
         }
         
-        // Verificar liquidez
-        if(!CCoreUtils::IsLiquidityHours(currentTime))
+        // Verificar liquidez conforme configuração
+        if(Signal_OnlyLiquidityHours && !CCoreUtils::IsLiquidityHours(currentTime))
         {
             return false;
         }
@@ -513,8 +515,9 @@ private:
             atr = CCoreUtils::CalculateATR(high, low, close, 20);
         }
 
-        if(atr <= 0) atr = 100; // Valor padrão em pontos
-        
+        if(atr <= 0)
+            atr = CCoreUtils::PointsToPrice(100, m_symbol); // Valor padrão em 100 pontos
+
         double stopDistance = atr * STOP_LOSS_ATR_MULTIPLIER;
         double takeProfitDistance = stopDistance * RISK_REWARD_RATIO;
         
@@ -531,19 +534,15 @@ private:
             stopDistance *= 1.2;
         }
         
-        // Converter para preços
-        double stopPoints = CCoreUtils::PointsToPrice(stopDistance, m_symbol);
-        double tpPoints = CCoreUtils::PointsToPrice(takeProfitDistance, m_symbol);
-        
         if(direction == TREND_UP)
         {
-            m_currentSignal.stopLoss = m_currentSignal.entryPrice - stopPoints;
-            m_currentSignal.takeProfit = m_currentSignal.entryPrice + tpPoints;
+            m_currentSignal.stopLoss = m_currentSignal.entryPrice - stopDistance;
+            m_currentSignal.takeProfit = m_currentSignal.entryPrice + takeProfitDistance;
         }
         else
         {
-            m_currentSignal.stopLoss = m_currentSignal.entryPrice + stopPoints;
-            m_currentSignal.takeProfit = m_currentSignal.entryPrice - tpPoints;
+            m_currentSignal.stopLoss = m_currentSignal.entryPrice + stopDistance;
+            m_currentSignal.takeProfit = m_currentSignal.entryPrice - takeProfitDistance;
         }
         
         // Calcular risk/reward

--- a/SignalGeneration/SignalGenerator.mqh
+++ b/SignalGeneration/SignalGenerator.mqh
@@ -16,7 +16,6 @@
 #include "../TimeframeAnalysis/TimeframeSequencer.mqh"
 #include "ConfluenceAnalyzer.mqh"
 
-extern bool Signal_OnlyLiquidityHours;
 
 //+------------------------------------------------------------------+
 //| Classe Geradora de Sinais                                       |

--- a/TradeExecution/TradeExecutor.mqh
+++ b/TradeExecution/TradeExecutor.mqh
@@ -14,6 +14,13 @@
 #include "../TrendAnalyzerConfig.mqh"
 #include "../Core/CoreUtils.mqh"
 
+extern int    g_winningTrades;
+extern int    g_losingTrades;
+extern double g_dailyProfit;
+extern double g_dailyLoss;
+extern double g_totalProfit;
+extern double g_totalLoss;
+
 //+------------------------------------------------------------------+
 //| Classe Executora de Trades                                      |
 //+------------------------------------------------------------------+
@@ -662,39 +669,47 @@ private:
     void OnPositionClosed()
     {
         // Atualizar estatísticas
+        double positionProfit = 0;
+
         if(HistorySelectByPosition(m_currentTicket))
         {
             int dealsTotal = HistoryDealsTotal();
-            
+
             for(int i = 0; i < dealsTotal; i++)
             {
                 ulong dealTicket = HistoryDealGetTicket(i);
-                
+
                 if(HistoryDealGetInteger(dealTicket, DEAL_POSITION_ID) == m_currentTicket)
                 {
-                    double profit = HistoryDealGetDouble(dealTicket, DEAL_PROFIT);
-                    
-                    if(profit > 0)
-                    {
-                        m_winningTrades++;
-                        m_totalProfit += profit;
-                    }
-                    else if(profit < 0)
-                    {
-                        m_losingTrades++;
-                        m_totalLoss += MathAbs(profit);
-                    }
-                    
-                    break;
+                    positionProfit += HistoryDealGetDouble(dealTicket, DEAL_PROFIT);
                 }
             }
         }
+
+        if(positionProfit > 0)
+        {
+            m_winningTrades++;
+            m_totalProfit += positionProfit;
+
+            g_winningTrades++;
+            g_totalProfit += positionProfit;
+            g_dailyProfit += positionProfit;
+        }
+        else if(positionProfit < 0)
+        {
+            m_losingTrades++;
+            m_totalLoss += MathAbs(positionProfit);
+
+            g_losingTrades++;
+            g_totalLoss += MathAbs(positionProfit);
+            g_dailyLoss += MathAbs(positionProfit);
+        }
         
+        CCoreUtils::LogInfo("Posição fechada - Ticket: " + IntegerToString(m_currentTicket));
+
         m_hasPosition = false;
         m_currentTicket = 0;
         m_partialClosed = false;
-        
-        CCoreUtils::LogInfo("Posição fechada - Ticket: " + IntegerToString(m_currentTicket));
     }
     
 public:


### PR DESCRIPTION
## Summary
- correct bullish/bearish bar check in trend strength calculation
- respect `Signal_OnlyLiquidityHours` when generating new signals
- use ATR directly for stop/target distances
- update global statistics when closing positions and handle partial closes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6857622b66d88320a2213fd8f4b4bcf8