### PR TITLE
Fix parameter compatibility in TrendLines and MultiTimeframe

### DIFF
--- a/PriceAction/TrendLines.mqh
+++ b/PriceAction/TrendLines.mqh
@@ -331,9 +331,9 @@ private:
             return false;
         }
         
-        return CCoreUtils::ValidateArrayData(m_high, bars) &&
-               CCoreUtils::ValidateArrayData(m_low, bars) &&
-               CCoreUtils::ValidateArrayData(m_close, bars);
+        return CCoreUtils::ValidateArrayData(m_high, bars, "High") &&
+               CCoreUtils::ValidateArrayData(m_low, bars, "Low") &&
+               CCoreUtils::ValidateArrayData(m_close, bars, "Close");
     }
     
     //+------------------------------------------------------------------+

--- a/SignalGeneration/SignalGenerator.mqh
+++ b/SignalGeneration/SignalGenerator.mqh
@@ -174,6 +174,9 @@ public:
         InitializeSignal(m_currentSignal);
         m_currentSignal.symbol = m_symbol;
         m_currentSignal.timestamp = TimeCurrent();
+        string timestampStr = TimeToString(m_currentSignal.timestamp,
+                                           TIME_DATE|TIME_SECONDS);
+        CCoreUtils::LogInfo("Timestamp do sinal: " + timestampStr);
         
         // Executar análise multi-timeframe
         if(!m_multiTimeframe.AnalyzeAllTimeframes(m_symbol))

--- a/TimeframeAnalysis/MultiTimeframe.mqh
+++ b/TimeframeAnalysis/MultiTimeframe.mqh
@@ -116,7 +116,13 @@ public:
     //+------------------------------------------------------------------+
     bool AnalyzeAllTimeframes(string symbol = "")
     {
-        if(symbol != "") m_symbol = symbol;
+        if(symbol != "")
+            m_symbol = symbol;
+        else if(m_symbol == "")
+        {
+            CCoreUtils::LogError("Símbolo não especificado para AnalyzeAllTimeframes");
+            return false;
+        }
         
         if(!m_initialized)
         {


### PR DESCRIPTION
## Summary
- ensure ValidateArrayData includes array names
- log timestamp during signal generation
- validate optional symbol when running multi-timeframe analysis

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6858485c2ad083208988e7a11cd0e00b