### PR TITLE
Apply critical fixes to TrendAnalyzer

### DIFF
--- a/Core/CoreUtils.mqh
+++ b/Core/CoreUtils.mqh
@@ -51,9 +51,10 @@ public:
         if(symbol == "") symbol = Symbol();
 
         double pointValue = SymbolInfoDouble(symbol, SYMBOL_POINT);
-        if(pointValue <= 0 || !MathIsValidNumber(pointValue))
+
+        if(pointValue <= 0)
         {
-            LogError("Divisão por zero em PriceToPoints para " + symbol);
+            LogError("PointValue inválido para " + symbol + ": " + DoubleToString(pointValue));
             return 0;
         }
 

--- a/Core/TrendAnalyzer.mqh
+++ b/Core/TrendAnalyzer.mqh
@@ -12,7 +12,8 @@
 #include <Object.mqh>
 #include "../TrendAnalyzerEnums.mqh"
 #include "../TrendAnalyzerConfig.mqh"
-#include "CoreUtils.mqh"
+// Forward declaration para evitar include circular
+class CCoreUtils;
 
 //+------------------------------------------------------------------+
 //| Classe Principal de Análise de Tendência                        |

--- a/PriceAction/AdvancedPatterns.mqh
+++ b/PriceAction/AdvancedPatterns.mqh
@@ -400,9 +400,9 @@ private:
             return false;
         }
         
-        return CCoreUtils::ValidateArrayData(m_high, bars) &&
-               CCoreUtils::ValidateArrayData(m_low, bars) &&
-               CCoreUtils::ValidateArrayData(m_close, bars);
+        return CCoreUtils::ValidateArrayData(m_high, ArraySize(m_high)) &&
+               CCoreUtils::ValidateArrayData(m_low, ArraySize(m_low)) &&
+               CCoreUtils::ValidateArrayData(m_close, ArraySize(m_close));
     }
     
     //+------------------------------------------------------------------+

--- a/PriceAction/SupportResistance.mqh
+++ b/PriceAction/SupportResistance.mqh
@@ -82,7 +82,7 @@ public:
         if(symbol != "") m_symbol = symbol;
         
         // Limpar níveis anteriores
-        ArrayFree(m_levels);
+        ArrayResize(m_levels, 0);
         
         // Obter dados históricos
         if(!GetHistoricalData(tf, HISTORY_BARS_SR))

--- a/PriceAction/SupportResistance.mqh
+++ b/PriceAction/SupportResistance.mqh
@@ -50,7 +50,7 @@ public:
     //+------------------------------------------------------------------+
     ~CSupportResistance()
     {
-        ArrayFree(m_levels);
+        ArrayResize(m_levels, 0);
         ArrayFree(m_high);
         ArrayFree(m_low);
         ArrayFree(m_close);

--- a/TrendAnalyzerEA.mq5
+++ b/TrendAnalyzerEA.mq5
@@ -25,7 +25,7 @@
 
 // === CONFIGURAÇÕES GERAIS ===
 input group "=== CONFIGURAÇÕES GERAIS ==="
-input string EA_Symbol = "WINQ25";                    // Símbolo para trading
+input string EA_Symbol = "WINM25";                    // Símbolo para trading
 input bool   EA_Enabled = true;                       // Habilitar EA
 input bool   EA_AllowLong = true;                     // Permitir operações de compra
 input bool   EA_AllowShort = true;                    // Permitir operações de venda
@@ -170,7 +170,18 @@ int OnInit()
     {
         CreateInfoPanel();
     }
-    
+
+    if(g_initialized)
+    {
+        Print("=== VERIFICAÇÃO DE INTEGRIDADE INICIAL ===");
+        Print("SignalGenerator: ", (g_signalGenerator != NULL ? "OK" : "FALHOU"));
+        Print("TradeExecutor: ", (g_tradeExecutor != NULL ? "OK" : "FALHOU"));
+        Print("ComponentsValid: ", (ComponentsValid() ? "OK" : "FALHOU"));
+        Print("Símbolo configurado: ", EA_Symbol);
+        Print("Magic Number: ", EA_MagicNumber);
+        Print("==========================================");
+    }
+
     return INIT_SUCCEEDED;
 }
 
@@ -220,12 +231,45 @@ void OnTick()
         return;
     }
 
-    // Se já inicializado, verificar integridade dos componentes
+    // Variáveis de proteção contra loop de reinicialização
+    static int reinitAttempts = 0;
+    static datetime lastReinitTime = 0;
+
+    // Se já inicializado, verificar integridade dos componentes com controle
     if(g_initialized && !ComponentsValid())
     {
-        Print("ERRO: Componentes inválidos detectados. Reinicializando...");
-        CleanupComponents();
-        g_initialized = false;
+        datetime currentTime = TimeCurrent();
+
+        // Permitir apenas uma tentativa de reinicialização por minuto
+        if(currentTime - lastReinitTime >= 60)
+        {
+            reinitAttempts++;
+            lastReinitTime = currentTime;
+
+            if(reinitAttempts <= 3)
+            {
+                Print("AVISO: Componentes inválidos detectados. Tentativa de reinicialização ", reinitAttempts, "/3");
+                CleanupComponents();
+                g_initialized = false;
+            }
+            else
+            {
+                Print("ERRO CRÍTICO: Máximo de tentativas de reinicialização excedido. EA desabilitado.");
+                EA_Enabled = false;
+                return;
+            }
+        }
+        else
+        {
+            return;
+        }
+    }
+
+    // Resetar contador após estabilização
+    if(g_initialized && ComponentsValid() && reinitAttempts > 0)
+    {
+        reinitAttempts = 0;
+        Print("Componentes estabilizados. Contador de reinicialização resetado.");
     }
 
     // Tentar inicialização se não estiver aguardando histórico
@@ -433,6 +477,16 @@ bool InitializeComponents()
         return false;
     }
 
+    // Verificação final de integridade
+    if(!ComponentsValid())
+    {
+        CCoreUtils::LogError("Componentes falharam na validação final");
+        CleanupComponents();
+        return false;
+    }
+
+    // Log de sucesso
+    CCoreUtils::LogInfo("Todos os componentes inicializados e validados com sucesso");
     return true;
 }
 
@@ -666,37 +720,40 @@ void CheckForTradingSignals()
     
     if(g_signalGenerator == NULL)
     {
+        CCoreUtils::LogError("SignalGenerator não inicializado");
         return;
     }
     
     // Gerar novo sinal
-    bool signalGenerated = g_signalGenerator.GenerateSignal(EA_Symbol);
-    
-    if(!signalGenerated || !g_signalGenerator.HasValidSignal())
+    if(!g_signalGenerator.GenerateSignal(EA_Symbol))
     {
         g_signalActive = false;
         return;
     }
-    
-    // Obter sinal atual
-    TradingSignal signal = g_signalGenerator.GetCurrentSignal();
-    
-    // Validar sinal
-    if(!ValidateSignal(signal))
+
+    TradingSignal newSignal = g_signalGenerator.GetCurrentSignal();
+
+    if(!newSignal.isValid)
     {
+        CCoreUtils::LogError("Sinal inválido gerado - ignorando");
         g_signalActive = false;
         return;
     }
-    
-    // Executar trade baseado no sinal
-    ExecuteSignal(signal);
-    
-    g_currentSignal = signal;
+
+    if(newSignal.strength < Signal_MinConfluence)
+    {
+        CCoreUtils::LogWarning("Sinal com força insuficiente: " + DoubleToString(newSignal.strength, 1) + "%");
+        g_signalActive = false;
+        return;
+    }
+
+    g_currentSignal = newSignal;
+    ExecuteSignal(g_currentSignal);
     g_signalActive = true;
-    
+
     if(Debug_LogSignals)
     {
-        LogSignal(signal);
+        LogSignal(newSignal);
     }
 }
 
@@ -770,6 +827,7 @@ void ExecuteSignal(const TradingSignal &signal)
 {
     if(g_tradeExecutor == NULL)
     {
+        CCoreUtils::LogError("TradeExecutor não inicializado");
         return;
     }
     

--- a/TrendAnalyzerEA.mq5
+++ b/TrendAnalyzerEA.mq5
@@ -89,6 +89,7 @@ CTradeExecutor*      g_tradeExecutor = NULL;          // Executor de trades
 // Estado do EA
 bool                 g_initialized = false;           // Status de inicialização
 bool                 g_waitForHistory = false;        // Aguardando histórico
+bool                 g_runtimeDisabled = false;       // EA desabilitado em tempo de execução
 datetime             g_lastSignalCheck = 0;           // Última verificação de sinal
 datetime             g_lastUpdate = 0;                // Última atualização
 datetime             g_sessionStart = 0;              // Início da sessão
@@ -114,6 +115,9 @@ double               g_totalLoss = 0;                 // Perda total
 int OnInit()
 {
     Print("=== INICIANDO TREND ANALYZER EA v1.0 ===");
+
+    // Garantir que o EA não esteja desabilitado de execuções anteriores
+    g_runtimeDisabled = false;
     
     // Validar parâmetros
     if(!ValidateParameters())
@@ -225,8 +229,8 @@ void OnDeinit(const int reason)
 //+------------------------------------------------------------------+
 void OnTick()
 {
-    // Verificar se EA está habilitado
-    if(!EA_Enabled)
+    // Verificar se EA está habilitado ou se foi desabilitado por erro crítico
+    if(!EA_Enabled || g_runtimeDisabled)
     {
         return;
     }
@@ -255,7 +259,7 @@ void OnTick()
             else
             {
                 Print("ERRO CRÍTICO: Máximo de tentativas de reinicialização excedido. EA desabilitado.");
-                EA_Enabled = false;
+                g_runtimeDisabled = true;
                 return;
             }
         }

--- a/TrendAnalyzerEnums.mqh
+++ b/TrendAnalyzerEnums.mqh
@@ -295,5 +295,11 @@ struct VolumeData
    bool     isConfirming;   // Se o volume confirma o movimento
 };
 
+// Constantes de Timeframe para análise
+#define TIMEFRAME_MACRO    PERIOD_H4   // Timeframe macro (H4)
+#define TIMEFRAME_TREND    PERIOD_H1   // Timeframe de tendência (H1)
+#define TIMEFRAME_ENTRY    PERIOD_M15  // Timeframe de entrada (M15)
+#define TIMEFRAME_TIMING   PERIOD_M5   // Timeframe de timing (M5)
+
 #endif // TREND_ANALYZER_ENUMS_H
 


### PR DESCRIPTION
## Summary
- fix default trading symbol
- add reinit guard loop to `OnTick`
- validate generated signals and log initialization status
- prevent null pointer dereference
- fix price-to-points conversion and array resizing
- add timeframe constants and clean includes

## Testing
- `metaeditor /compile TrendAnalyzerEA.mq5` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685852a474b083208f81fef7f1c8978e