### PR TITLE
Add chart object drawing module

### DIFF
--- a/ChartObjects/ChartDrawer.mqh
+++ b/ChartObjects/ChartDrawer.mqh
@@ -1,0 +1,141 @@
+//+------------------------------------------------------------------+
+//| ChartDrawer.mqh - Desenho de Objetos no Gráfico                  |
+//| Desenvolvido por: Manus AI                                       |
+//| Versão: 1.0                                                      |
+//| Data: 2025-06-21                                                 |
+//+------------------------------------------------------------------+
+
+#ifndef CHART_DRAWER_H
+#define CHART_DRAWER_H
+
+#include "../TrendAnalyzerEnums.mqh"
+#include "../TrendAnalyzerConfig.mqh"
+#include "../Core/CoreUtils.mqh"
+#include "../PriceAction/TrendLines.mqh"
+#include "../PriceAction/SupportResistance.mqh"
+
+//+------------------------------------------------------------------+
+//| Classe responsável por desenhar e atualizar objetos no gráfico   |
+//+------------------------------------------------------------------+
+class CChartDrawer : public CObject
+{
+private:
+    string m_symbol; // Símbolo utilizado
+
+public:
+    //+------------------------------------------------------------------+
+    //| Construtor                                                      |
+    //+------------------------------------------------------------------+
+    CChartDrawer()
+    {
+        m_symbol = "";
+    }
+
+    //+------------------------------------------------------------------+
+    //| Inicialização                                                   |
+    //+------------------------------------------------------------------+
+    bool Initialize(string symbol)
+    {
+        m_symbol = (symbol == "" || symbol == NULL) ? Symbol() : symbol;
+        return true;
+    }
+
+    //+------------------------------------------------------------------+
+    //| Atualizar linhas de tendência                                   |
+    //+------------------------------------------------------------------+
+    void UpdateTrendLines(CTrendLines &trendLines)
+    {
+        DrawTrendLine(trendLines.GetLTA(), "LTA_" + m_symbol, clrLime);
+        DrawTrendLine(trendLines.GetLTB(), "LTB_" + m_symbol, clrRed);
+    }
+
+    //+------------------------------------------------------------------+
+    //| Atualizar níveis de suporte/resistência                         |
+    //+------------------------------------------------------------------+
+    void UpdateSupportResistance(CSupportResistance &sr, int maxLevels=5)
+    {
+        string prefixSup = "SUP_" + m_symbol + "_";
+        string prefixRes = "RES_" + m_symbol + "_";
+
+        // Limpar objetos existentes
+        DeleteObjectsByPrefix(prefixSup);
+        DeleteObjectsByPrefix(prefixRes);
+
+        SR_Level levels[];
+        sr.GetAllLevels(levels);
+        int count = MathMin(ArraySize(levels), maxLevels);
+
+        for(int i=0; i<count; i++)
+        {
+            string objName = (levels[i].isSupport ? prefixSup : prefixRes) + IntegerToString(i);
+            color  objColor = levels[i].isSupport ? clrDodgerBlue : clrOrange;
+            DrawHLine(levels[i].price, objName, objColor);
+        }
+    }
+
+private:
+    //+------------------------------------------------------------------+
+    //| Desenhar ou atualizar linha de tendência                        |
+    //+------------------------------------------------------------------+
+    void DrawTrendLine(const TrendLine &line, string name, color clr)
+    {
+        if(!line.isValid)
+        {
+            ObjectDelete(0, name);
+            return;
+        }
+
+        if(!ObjectFind(0, name))
+        {
+            ObjectCreate(0, name, OBJ_TREND, 0, line.time1, line.price1, line.time2, line.price2);
+            ObjectSetInteger(0, name, OBJPROP_COLOR, clr);
+            ObjectSetInteger(0, name, OBJPROP_RAY_RIGHT, true);
+            ObjectSetInteger(0, name, OBJPROP_WIDTH, 2);
+        }
+        else
+        {
+            ObjectMove(0, name, 0, line.time1, line.price1);
+            ObjectMove(0, name, 1, line.time2, line.price2);
+        }
+    }
+
+    //+------------------------------------------------------------------+
+    //| Desenhar ou atualizar linha horizontal                           |
+    //+------------------------------------------------------------------+
+    void DrawHLine(double price, string name, color clr)
+    {
+        if(price == 0)
+        {
+            ObjectDelete(0, name);
+            return;
+        }
+
+        if(!ObjectFind(0, name))
+        {
+            ObjectCreate(0, name, OBJ_HLINE, 0, TimeCurrent(), price);
+            ObjectSetInteger(0, name, OBJPROP_COLOR, clr);
+            ObjectSetInteger(0, name, OBJPROP_STYLE, STYLE_DASH);
+            ObjectSetInteger(0, name, OBJPROP_WIDTH, 1);
+        }
+        else
+        {
+            ObjectSetDouble(0, name, OBJPROP_PRICE, price);
+        }
+    }
+
+    //+------------------------------------------------------------------+
+    //| Remover objetos com prefixo específico                           |
+    //+------------------------------------------------------------------+
+    void DeleteObjectsByPrefix(string prefix)
+    {
+        int total = ObjectsTotal(0, -1, -1);
+        for(int i = total - 1; i >= 0; i--)
+        {
+            string objName = ObjectName(0, i, -1, -1);
+            if(StringFind(objName, prefix) == 0)
+                ObjectDelete(0, objName);
+        }
+    }
+};
+
+#endif // CHART_DRAWER_H

--- a/PriceAction/SupportResistance.mqh
+++ b/PriceAction/SupportResistance.mqh
@@ -11,6 +11,7 @@
 #include "../TrendAnalyzerEnums.mqh"
 #include "../TrendAnalyzerConfig.mqh"
 #include "../Core/CoreUtils.mqh"
+#include "../ChartObjects/ChartDrawer.mqh"
 
 //+------------------------------------------------------------------+
 //| Classe de Suporte e Resistência                                 |
@@ -20,6 +21,7 @@ class CSupportResistance : public CObject
 private:
     SR_Level             m_levels[];         // Níveis identificados
     string               m_symbol;           // Símbolo
+    CChartDrawer*        m_drawer;           // Desenhador de objetos
     
     // Arrays para análise
     double               m_high[];           // Máximas
@@ -35,7 +37,8 @@ public:
     CSupportResistance()
     {
         m_symbol = "";
-        
+        m_drawer = NULL;
+
         ArraySetAsSeries(m_high, true);
         ArraySetAsSeries(m_low, true);
         ArraySetAsSeries(m_close, true);
@@ -66,10 +69,18 @@ public:
             CCoreUtils::LogError("Símbolo inválido para SupportResistance");
             return false;
         }
-        
+
         m_symbol = symbol;
         CCoreUtils::LogInfo("SupportResistance inicializado para " + symbol);
         return true;
+    }
+
+    //+------------------------------------------------------------------+
+    //| Definir objeto de desenho                                       |
+    //+------------------------------------------------------------------+
+    void SetChartDrawer(CChartDrawer* drawer)
+    {
+        m_drawer = drawer;
     }
     
     //+------------------------------------------------------------------+
@@ -100,8 +111,9 @@ public:
         
         // Ordenar por relevância
         SortLevelsByRelevance();
-        
+
         CCoreUtils::LogInfo("Identificados " + IntegerToString(ArraySize(m_levels)) + " níveis S/R");
+        if(m_drawer != NULL) m_drawer->UpdateSupportResistance(*this);
     }
     
     //+------------------------------------------------------------------+

--- a/PriceAction/TrendLines.mqh
+++ b/PriceAction/TrendLines.mqh
@@ -11,6 +11,7 @@
 #include "../TrendAnalyzerEnums.mqh"
 #include "../TrendAnalyzerConfig.mqh"
 #include "../Core/CoreUtils.mqh"
+#include "../ChartObjects/ChartDrawer.mqh"
 
 //+------------------------------------------------------------------+
 //| Classe de Linhas de Tendência                                   |
@@ -21,6 +22,7 @@ private:
     TrendLine            m_lta;              // Linha de Tendência de Alta
     TrendLine            m_ltb;              // Linha de Tendência de Baixa
     string               m_symbol;           // Símbolo
+    CChartDrawer*        m_drawer;           // Desenhador de objetos
     
     // Arrays para análise
     double               m_high[];           // Máximas
@@ -46,6 +48,7 @@ public:
     CTrendLines()
     {
         m_symbol = "";
+        m_drawer = NULL;
         InitializeTrendLine(m_lta);
         InitializeTrendLine(m_ltb);
         
@@ -77,10 +80,18 @@ public:
             CCoreUtils::LogError("Símbolo inválido para TrendLines");
             return false;
         }
-        
+
         m_symbol = symbol;
         CCoreUtils::LogInfo("TrendLines inicializado para " + symbol);
         return true;
+    }
+
+    //+------------------------------------------------------------------+
+    //| Definir objeto para desenho                                     |
+    //+------------------------------------------------------------------+
+    void SetChartDrawer(CChartDrawer* drawer)
+    {
+        m_drawer = drawer;
     }
     
     //+------------------------------------------------------------------+
@@ -94,6 +105,7 @@ public:
         if(!GetHistoricalData(tf, HISTORY_BARS_TRENDLINE))
         {
             CCoreUtils::LogError("Falha ao obter dados para LTA");
+            if(m_drawer != NULL) m_drawer->UpdateTrendLines(*this);
             return false;
         }
         
@@ -101,6 +113,7 @@ public:
         if(!IdentifyPivotPoints(false)) // false = fundos
         {
             CCoreUtils::LogError("Falha ao identificar fundos para LTA");
+            if(m_drawer != NULL) m_drawer->UpdateTrendLines(*this);
             return false;
         }
         
@@ -108,6 +121,7 @@ public:
         if(!FindBestTrendLine(false, m_lta)) // false = linha de alta (conecta fundos)
         {
             CCoreUtils::LogWarning("Não foi possível encontrar LTA válida");
+            if(m_drawer != NULL) m_drawer->UpdateTrendLines(*this);
             return false;
         }
         
@@ -115,10 +129,12 @@ public:
         if(!ValidateTrendLine(m_lta, false))
         {
             CCoreUtils::LogWarning("LTA não passou na validação");
+            if(m_drawer != NULL) m_drawer->UpdateTrendLines(*this);
             return false;
         }
         
         CCoreUtils::LogInfo("LTA calculada com sucesso. Toques: " + IntegerToString(m_lta.touches));
+        if(m_drawer != NULL) m_drawer->UpdateTrendLines(*this);
         return true;
     }
     
@@ -133,6 +149,7 @@ public:
         if(!GetHistoricalData(tf, HISTORY_BARS_TRENDLINE))
         {
             CCoreUtils::LogError("Falha ao obter dados para LTB");
+            if(m_drawer != NULL) m_drawer->UpdateTrendLines(*this);
             return false;
         }
         
@@ -140,6 +157,7 @@ public:
         if(!IdentifyPivotPoints(true)) // true = topos
         {
             CCoreUtils::LogError("Falha ao identificar topos para LTB");
+            if(m_drawer != NULL) m_drawer->UpdateTrendLines(*this);
             return false;
         }
         
@@ -147,6 +165,7 @@ public:
         if(!FindBestTrendLine(true, m_ltb)) // true = linha de baixa (conecta topos)
         {
             CCoreUtils::LogWarning("Não foi possível encontrar LTB válida");
+            if(m_drawer != NULL) m_drawer->UpdateTrendLines(*this);
             return false;
         }
         
@@ -154,10 +173,12 @@ public:
         if(!ValidateTrendLine(m_ltb, true))
         {
             CCoreUtils::LogWarning("LTB não passou na validação");
+            if(m_drawer != NULL) m_drawer->UpdateTrendLines(*this);
             return false;
         }
         
         CCoreUtils::LogInfo("LTB calculada com sucesso. Toques: " + IntegerToString(m_ltb.touches));
+        if(m_drawer != NULL) m_drawer->UpdateTrendLines(*this);
         return true;
     }
     

--- a/SignalGeneration/ConfluenceAnalyzer.mqh
+++ b/SignalGeneration/ConfluenceAnalyzer.mqh
@@ -19,6 +19,7 @@
 #include "../Indicators/BollingerBands.mqh"
 #include "../Indicators/Fibonacci.mqh"
 #include "../Indicators/VolumeAnalyzer.mqh"
+#include "../ChartObjects/ChartDrawer.mqh"
 
 //+------------------------------------------------------------------+
 //| Classe Analisadora de Confluência                               |
@@ -27,6 +28,7 @@ class CConfluenceAnalyzer : public CObject
 {
 private:
     string               m_symbol;           // Símbolo
+    CChartDrawer*        m_drawer;           // Desenhador de objetos
     
     // Componentes de análise
     CTrendLines*         m_trendLines;       // Linhas de tendência
@@ -55,7 +57,8 @@ public:
     CConfluenceAnalyzer()
     {
         m_symbol = "";
-        
+        m_drawer = NULL;
+
         m_trendLines = NULL;
         m_supRes = NULL;
         m_channels = NULL;
@@ -122,6 +125,12 @@ public:
         allInitialized &= m_bollingerBands.Initialize(symbol);
         allInitialized &= m_fibonacci.Initialize(symbol);
         allInitialized &= m_volumeAnalyzer.Initialize(symbol);
+
+        if(m_drawer != NULL)
+        {
+            m_trendLines.SetChartDrawer(m_drawer);
+            m_supRes.SetChartDrawer(m_drawer);
+        }
         
         if(!allInitialized)
         {
@@ -131,8 +140,18 @@ public:
         
         m_initialized = true;
         CCoreUtils::LogInfo("ConfluenceAnalyzer inicializado com sucesso para " + symbol);
-        
+
         return true;
+    }
+
+    //+------------------------------------------------------------------+
+    //| Definir objeto de desenho                                       |
+    //+------------------------------------------------------------------+
+    void SetChartDrawer(CChartDrawer* drawer)
+    {
+        m_drawer = drawer;
+        if(m_trendLines != NULL) m_trendLines.SetChartDrawer(drawer);
+        if(m_supRes != NULL) m_supRes.SetChartDrawer(drawer);
     }
     
     //+------------------------------------------------------------------+

--- a/SignalGeneration/SignalGenerator.mqh
+++ b/SignalGeneration/SignalGenerator.mqh
@@ -14,6 +14,7 @@
 #include "../TimeframeAnalysis/MultiTimeframe.mqh"
 #include "../TimeframeAnalysis/TimeframeSequencer.mqh"
 #include "ConfluenceAnalyzer.mqh"
+#include "../ChartObjects/ChartDrawer.mqh"
 
 //+------------------------------------------------------------------+
 //| Classe Geradora de Sinais                                       |
@@ -27,6 +28,7 @@ private:
     CMultiTimeframe*     m_multiTimeframe;   // Análise multi-timeframe
     CTimeframeSequencer* m_sequencer;        // Sequenciador
     CConfluenceAnalyzer* m_confluence;       // Analisador de confluência
+    CChartDrawer*        m_drawer;           // Desenhador de objetos
     
     // Sinais gerados
     TradingSignal        m_currentSignal;    // Sinal atual
@@ -48,6 +50,8 @@ public:
     CSignalGenerator()
     {
         m_symbol = "";
+
+        m_drawer = NULL;
         
         m_multiTimeframe = NULL;
         m_sequencer = NULL;
@@ -112,11 +116,22 @@ public:
             CCoreUtils::LogError("Falha ao inicializar ConfluenceAnalyzer");
             return false;
         }
+        if(m_drawer != NULL)
+            m_confluence.SetChartDrawer(m_drawer);
         
         m_initialized = true;
         CCoreUtils::LogInfo("SignalGenerator inicializado com sucesso para " + symbol);
-        
+
         return true;
+    }
+
+    //+------------------------------------------------------------------+
+    //| Definir objeto de desenho                                       |
+    //+------------------------------------------------------------------+
+    void SetChartDrawer(CChartDrawer* drawer)
+    {
+        m_drawer = drawer;
+        if(m_confluence != NULL) m_confluence.SetChartDrawer(drawer);
     }
     
     //+------------------------------------------------------------------+

--- a/TrendAnalyzerEA.mq5
+++ b/TrendAnalyzerEA.mq5
@@ -17,6 +17,7 @@
 #include "Core/CoreUtils.mqh"
 #include "SignalGeneration/SignalGenerator.mqh"
 #include "TradeExecution/TradeExecutor.mqh"
+#include "ChartObjects/ChartDrawer.mqh"
 
 //+------------------------------------------------------------------+
 //| Parâmetros de entrada do EA                                     |
@@ -84,6 +85,7 @@ input bool   Debug_LogTrades = true;                  // Log de trades
 // Componentes principais
 CSignalGenerator*    g_signalGenerator = NULL;        // Gerador de sinais
 CTradeExecutor*      g_tradeExecutor = NULL;          // Executor de trades
+CChartDrawer*       g_chartDrawer = NULL;            // Desenhador de objetos
 
 // Estado do EA
 bool                 g_initialized = false;           // Status de inicialização
@@ -121,6 +123,9 @@ int OnInit()
     }
     
     // Inicializar componentes
+    g_chartDrawer = new CChartDrawer();
+    g_chartDrawer.Initialize(EA_Symbol);
+
     if(!InitializeComponents())
     {
         Print("ERRO: Falha na inicialização dos componentes");
@@ -169,6 +174,12 @@ void OnDeinit(const int reason)
     {
         delete g_tradeExecutor;
         g_tradeExecutor = NULL;
+    }
+
+    if(g_chartDrawer != NULL)
+    {
+        delete g_chartDrawer;
+        g_chartDrawer = NULL;
     }
     
     // Remover objetos gráficos
@@ -309,6 +320,8 @@ bool InitializeComponents()
         Print("ERRO: Falha ao inicializar SignalGenerator");
         return false;
     }
+    if(g_chartDrawer != NULL)
+        g_signalGenerator.SetChartDrawer(g_chartDrawer);
     
     // Criar executor de trades
     g_tradeExecutor = new CTradeExecutor();


### PR DESCRIPTION
## Summary
- add `ChartDrawer` class for chart drawing
- integrate drawing into price action modules
- allow confluence analyzer and signal generator to use chart drawer
- update EA to create and manage chart drawer

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685867116a208320961b9c10ae3f734d