### PR TITLE
Add trend and SR visualization module

### DIFF
--- a/PriceAction/PriceActionTest.mq5
+++ b/PriceAction/PriceActionTest.mq5
@@ -17,6 +17,7 @@
 #include "Channels.mqh"
 #include "AdvancedPatterns.mqh"
 #include "PriceActionUtils.mqh"
+#include "../Visualization/ValidationVisualizer.mqh"
 
 //+------------------------------------------------------------------+
 //| Parâmetros de entrada                                           |
@@ -66,12 +67,17 @@ bool TestTrendLines()
     Print("--- Teste 1: Linhas de Tendência ---");
     
     CTrendLines* trendLines = new CTrendLines();
+    CValidationVisualizer* viz = new CValidationVisualizer();
+
+    viz.Initialize(TestSymbol);
+    trendLines.SetVisualizer(viz);
     
     // Inicializar
     if(!trendLines.Initialize(TestSymbol))
     {
         Print("FALHA: Não foi possível inicializar TrendLines");
         delete trendLines;
+        delete viz;
         return false;
     }
     
@@ -105,6 +111,7 @@ bool TestTrendLines()
     }
     
     delete trendLines;
+    delete viz;
     
     Print("SUCESSO: Teste de Linhas de Tendência");
     return true;
@@ -118,12 +125,17 @@ bool TestSupportResistance()
     Print("--- Teste 2: Suporte e Resistência ---");
     
     CSupportResistance* sr = new CSupportResistance();
+    CValidationVisualizer* viz = new CValidationVisualizer();
+
+    viz.Initialize(TestSymbol);
+    sr.SetVisualizer(viz);
     
     // Inicializar
     if(!sr.Initialize(TestSymbol))
     {
         Print("FALHA: Não foi possível inicializar SupportResistance");
         delete sr;
+        delete viz;
         return false;
     }
     
@@ -158,6 +170,7 @@ bool TestSupportResistance()
     }
     
     delete sr;
+    delete viz;
     
     Print("SUCESSO: Teste de Suporte e Resistência");
     return true;

--- a/PriceAction/SupportResistance.mqh
+++ b/PriceAction/SupportResistance.mqh
@@ -13,8 +13,7 @@
 #include "../TrendAnalyzerEnums.mqh"
 #include "../TrendAnalyzerConfig.mqh"
 #include "../Core/CoreUtils.mqh"
-
-class CValidationVisualizer;
+#include "../Visualization/IValidationVisualizer.mqh"
 
 //+------------------------------------------------------------------+
 //| Classe de Suporte e Resistência                                 |
@@ -24,7 +23,7 @@ class CSupportResistance : public CObject
 private:
     SR_Level             m_levels[];         // Níveis identificados
     string               m_symbol;           // Símbolo
-    CValidationVisualizer* m_visualizer;    // Visualizador opcional
+    IValidationVisualizer* m_visualizer;    // Visualizador opcional
     
     // Arrays para análise
     double               m_high[];           // Máximas
@@ -78,7 +77,7 @@ public:
         return true;
     }
 
-    void SetVisualizer(CValidationVisualizer* visualizer)
+    void SetVisualizer(IValidationVisualizer* visualizer)
     {
         m_visualizer = visualizer;
     }

--- a/PriceAction/SupportResistance.mqh
+++ b/PriceAction/SupportResistance.mqh
@@ -113,7 +113,7 @@ public:
 
         CCoreUtils::LogInfo("Identificados " + IntegerToString(ArraySize(m_levels)) + " níveis S/R");
         if(m_visualizer != NULL)
-            m_visualizer.UpdateSupportResistance(this);
+            m_visualizer.UpdateSupportResistance((const CSupportResistance*)this);
     }
     
     //+------------------------------------------------------------------+
@@ -299,7 +299,7 @@ public:
     //+------------------------------------------------------------------+
     //| Obter todos os níveis                                          |
     //+------------------------------------------------------------------+
-    void GetAllLevels(SR_Level &levels[])
+    void GetAllLevels(SR_Level &levels[]) const
     {
         ArrayResize(levels, ArraySize(m_levels));
         for(int i = 0; i < ArraySize(m_levels); i++)

--- a/PriceAction/SupportResistance.mqh
+++ b/PriceAction/SupportResistance.mqh
@@ -14,6 +14,8 @@
 #include "../TrendAnalyzerConfig.mqh"
 #include "../Core/CoreUtils.mqh"
 
+class CValidationVisualizer;
+
 //+------------------------------------------------------------------+
 //| Classe de Suporte e Resistência                                 |
 //+------------------------------------------------------------------+
@@ -22,6 +24,7 @@ class CSupportResistance : public CObject
 private:
     SR_Level             m_levels[];         // Níveis identificados
     string               m_symbol;           // Símbolo
+    CValidationVisualizer* m_visualizer;    // Visualizador opcional
     
     // Arrays para análise
     double               m_high[];           // Máximas
@@ -37,6 +40,7 @@ public:
     CSupportResistance()
     {
         m_symbol = "";
+        m_visualizer = NULL;
         
         ArraySetAsSeries(m_high, true);
         ArraySetAsSeries(m_low, true);
@@ -73,6 +77,11 @@ public:
         CCoreUtils::LogInfo("SupportResistance inicializado para " + symbol);
         return true;
     }
+
+    void SetVisualizer(CValidationVisualizer* visualizer)
+    {
+        m_visualizer = visualizer;
+    }
     
     //+------------------------------------------------------------------+
     //| Identificar níveis de suporte e resistência                    |
@@ -102,8 +111,10 @@ public:
         
         // Ordenar por relevância
         SortLevelsByRelevance();
-        
+
         CCoreUtils::LogInfo("Identificados " + IntegerToString(ArraySize(m_levels)) + " níveis S/R");
+        if(m_visualizer != NULL)
+            m_visualizer.UpdateSupportResistance(*this);
     }
     
     //+------------------------------------------------------------------+

--- a/PriceAction/SupportResistance.mqh
+++ b/PriceAction/SupportResistance.mqh
@@ -113,7 +113,7 @@ public:
 
         CCoreUtils::LogInfo("Identificados " + IntegerToString(ArraySize(m_levels)) + " níveis S/R");
         if(m_visualizer != NULL)
-            m_visualizer.UpdateSupportResistance(*this);
+            m_visualizer.UpdateSupportResistance(this);
     }
     
     //+------------------------------------------------------------------+

--- a/PriceAction/TrendLines.mqh
+++ b/PriceAction/TrendLines.mqh
@@ -13,8 +13,7 @@
 #include "../TrendAnalyzerEnums.mqh"
 #include "../TrendAnalyzerConfig.mqh"
 #include "../Core/CoreUtils.mqh"
-
-class CValidationVisualizer;
+#include "../Visualization/IValidationVisualizer.mqh"
 
 //+------------------------------------------------------------------+
 //| Classe de Linhas de Tendência                                   |
@@ -25,7 +24,7 @@ private:
     TrendLine            m_lta;              // Linha de Tendência de Alta
     TrendLine            m_ltb;              // Linha de Tendência de Baixa
     string               m_symbol;           // Símbolo
-    CValidationVisualizer* m_visualizer;    // Visualizador opcional
+    IValidationVisualizer* m_visualizer;    // Visualizador opcional
     
     // Arrays para análise
     double               m_high[];           // Máximas
@@ -89,7 +88,7 @@ public:
         return true;
     }
 
-    void SetVisualizer(CValidationVisualizer* visualizer)
+    void SetVisualizer(IValidationVisualizer* visualizer)
     {
         m_visualizer = visualizer;
     }

--- a/PriceAction/TrendLines.mqh
+++ b/PriceAction/TrendLines.mqh
@@ -130,7 +130,7 @@ public:
         
         CCoreUtils::LogInfo("LTA calculada com sucesso. Toques: " + IntegerToString(m_lta.touches));
         if(m_visualizer != NULL)
-            m_visualizer.UpdateTrendLines(*this);
+            m_visualizer.UpdateTrendLines(this);
         return true;
     }
     
@@ -171,7 +171,7 @@ public:
         
         CCoreUtils::LogInfo("LTB calculada com sucesso. Toques: " + IntegerToString(m_ltb.touches));
         if(m_visualizer != NULL)
-            m_visualizer.UpdateTrendLines(*this);
+            m_visualizer.UpdateTrendLines(this);
         return true;
     }
     

--- a/PriceAction/TrendLines.mqh
+++ b/PriceAction/TrendLines.mqh
@@ -14,6 +14,8 @@
 #include "../TrendAnalyzerConfig.mqh"
 #include "../Core/CoreUtils.mqh"
 
+class CValidationVisualizer;
+
 //+------------------------------------------------------------------+
 //| Classe de Linhas de Tendência                                   |
 //+------------------------------------------------------------------+
@@ -23,6 +25,7 @@ private:
     TrendLine            m_lta;              // Linha de Tendência de Alta
     TrendLine            m_ltb;              // Linha de Tendência de Baixa
     string               m_symbol;           // Símbolo
+    CValidationVisualizer* m_visualizer;    // Visualizador opcional
     
     // Arrays para análise
     double               m_high[];           // Máximas
@@ -48,6 +51,7 @@ public:
     CTrendLines()
     {
         m_symbol = "";
+        m_visualizer = NULL;
         InitializeTrendLine(m_lta);
         InitializeTrendLine(m_ltb);
         
@@ -79,10 +83,15 @@ public:
             CCoreUtils::LogError("Símbolo inválido para TrendLines");
             return false;
         }
-        
+
         m_symbol = symbol;
         CCoreUtils::LogInfo("TrendLines inicializado para " + symbol);
         return true;
+    }
+
+    void SetVisualizer(CValidationVisualizer* visualizer)
+    {
+        m_visualizer = visualizer;
     }
     
     //+------------------------------------------------------------------+
@@ -121,6 +130,8 @@ public:
         }
         
         CCoreUtils::LogInfo("LTA calculada com sucesso. Toques: " + IntegerToString(m_lta.touches));
+        if(m_visualizer != NULL)
+            m_visualizer.UpdateTrendLines(*this);
         return true;
     }
     
@@ -160,6 +171,8 @@ public:
         }
         
         CCoreUtils::LogInfo("LTB calculada com sucesso. Toques: " + IntegerToString(m_ltb.touches));
+        if(m_visualizer != NULL)
+            m_visualizer.UpdateTrendLines(*this);
         return true;
     }
     

--- a/PriceAction/TrendLines.mqh
+++ b/PriceAction/TrendLines.mqh
@@ -130,7 +130,7 @@ public:
         
         CCoreUtils::LogInfo("LTA calculada com sucesso. Toques: " + IntegerToString(m_lta.touches));
         if(m_visualizer != NULL)
-            m_visualizer.UpdateTrendLines(this);
+            m_visualizer.UpdateTrendLines((const CTrendLines*)this);
         return true;
     }
     
@@ -171,7 +171,7 @@ public:
         
         CCoreUtils::LogInfo("LTB calculada com sucesso. Toques: " + IntegerToString(m_ltb.touches));
         if(m_visualizer != NULL)
-            m_visualizer.UpdateTrendLines(this);
+            m_visualizer.UpdateTrendLines((const CTrendLines*)this);
         return true;
     }
     

--- a/Visualization/IValidationVisualizer.mqh
+++ b/Visualization/IValidationVisualizer.mqh
@@ -1,0 +1,27 @@
+//+------------------------------------------------------------------+
+//| IValidationVisualizer.mqh - Interface para visualização         |
+//| Desenvolvido por: Manus AI                                       |
+//| Versão: 1.0                                                      |
+//| Data: 2025-06-21                                                 |
+//+------------------------------------------------------------------+
+
+#ifndef I_VALIDATION_VISUALIZER_H
+#define I_VALIDATION_VISUALIZER_H
+#property strict
+
+#include <Object.mqh>
+
+class CTrendLines;
+class CSupportResistance;
+
+//+------------------------------------------------------------------+
+//| Interface para visualizadores de validação                       |
+//+------------------------------------------------------------------+
+class IValidationVisualizer : public CObject
+{
+public:
+    virtual void UpdateTrendLines(const CTrendLines &trendLines) = 0;
+    virtual void UpdateSupportResistance(const CSupportResistance &sr) = 0;
+};
+
+#endif // I_VALIDATION_VISUALIZER_H

--- a/Visualization/IValidationVisualizer.mqh
+++ b/Visualization/IValidationVisualizer.mqh
@@ -20,8 +20,11 @@ class CSupportResistance;
 class IValidationVisualizer : public CObject
 {
 public:
-    virtual void UpdateTrendLines(const CTrendLines &trendLines) = 0;
-    virtual void UpdateSupportResistance(const CSupportResistance &sr) = 0;
+    // Atualiza desenho das linhas de tendência durante a validação
+    virtual void UpdateTrendLines(const CTrendLines *trendLines) = 0;
+
+    // Atualiza desenho dos níveis de suporte e resistência
+    virtual void UpdateSupportResistance(const CSupportResistance *sr) = 0;
 };
 
 #endif // I_VALIDATION_VISUALIZER_H

--- a/Visualization/ValidationVisualizer.mqh
+++ b/Visualization/ValidationVisualizer.mqh
@@ -48,9 +48,9 @@ public:
     }
 
     // Desenhar/atualizar linhas de tendência
-    void UpdateTrendLines(const CTrendLines &trendLines)
+    void UpdateTrendLines(const CTrendLines *trendLines)
     {
-        if(trendLines.IsLTAValid())
+        if(trendLines != NULL && trendLines.IsLTAValid())
         {
             TrendLine lta = trendLines.GetLTA();
             CreateOrUpdateLine(m_ltaName, lta.time1, lta.price1, lta.time2, lta.price2, clrGreen);
@@ -60,7 +60,7 @@ public:
             ObjectDelete(m_chartID, m_ltaName);
         }
 
-        if(trendLines.IsLTBValid())
+        if(trendLines != NULL && trendLines.IsLTBValid())
         {
             TrendLine ltb = trendLines.GetLTB();
             CreateOrUpdateLine(m_ltbName, ltb.time1, ltb.price1, ltb.time2, ltb.price2, clrRed);
@@ -72,9 +72,12 @@ public:
     }
 
     // Desenhar/atualizar níveis de suporte e resistência
-    void UpdateSupportResistance(const CSupportResistance &sr)
+    void UpdateSupportResistance(const CSupportResistance *sr)
     {
         RemoveSRObjects();
+
+        if(sr == NULL)
+            return;
 
         SR_Level levels[];
         sr.GetAllLevels(levels);

--- a/Visualization/ValidationVisualizer.mqh
+++ b/Visualization/ValidationVisualizer.mqh
@@ -11,13 +11,14 @@
 
 #include <Object.mqh>
 #include "../TrendAnalyzerEnums.mqh"
+#include "IValidationVisualizer.mqh"
 #include "../PriceAction/TrendLines.mqh"
 #include "../PriceAction/SupportResistance.mqh"
 
 //+------------------------------------------------------------------+
 //| Classe para visualização de validações                           |
 //+------------------------------------------------------------------+
-class CValidationVisualizer : public CObject
+class CValidationVisualizer : public IValidationVisualizer
 {
 private:
     string m_symbol;        // Símbolo

--- a/Visualization/ValidationVisualizer.mqh
+++ b/Visualization/ValidationVisualizer.mqh
@@ -1,0 +1,137 @@
+//+------------------------------------------------------------------+
+//| ValidationVisualizer.mqh - Desenho de linhas de validação       |
+//| Desenvolvido por: Manus AI                                       |
+//| Versão: 1.0                                                      |
+//| Data: 2025-06-21                                                 |
+//+------------------------------------------------------------------+
+
+#ifndef VALIDATION_VISUALIZER_H
+#define VALIDATION_VISUALIZER_H
+#property strict
+
+#include <Object.mqh>
+#include "../TrendAnalyzerEnums.mqh"
+#include "../PriceAction/TrendLines.mqh"
+#include "../PriceAction/SupportResistance.mqh"
+
+//+------------------------------------------------------------------+
+//| Classe para visualização de validações                           |
+//+------------------------------------------------------------------+
+class CValidationVisualizer : public CObject
+{
+private:
+    string m_symbol;        // Símbolo
+    long   m_chartID;       // ID do gráfico
+    string m_ltaName;       // Nome do objeto LTA
+    string m_ltbName;       // Nome do objeto LTB
+    string m_srPrefix;      // Prefixo para níveis SR
+public:
+    // Construtor
+    CValidationVisualizer()
+    {
+        m_symbol   = "";
+        m_chartID  = 0;
+        m_ltaName  = "VALID_LTA";
+        m_ltbName  = "VALID_LTB";
+        m_srPrefix = "VALID_SR_";
+    }
+
+    // Inicializar
+    bool Initialize(string symbol, long chartID = 0)
+    {
+        if(symbol == "" || symbol == NULL)
+            return false;
+        m_symbol  = symbol;
+        m_chartID = (chartID == 0 ? ChartID() : chartID);
+        return true;
+    }
+
+    // Desenhar/atualizar linhas de tendência
+    void UpdateTrendLines(const CTrendLines &trendLines)
+    {
+        if(trendLines.IsLTAValid())
+        {
+            TrendLine lta = trendLines.GetLTA();
+            CreateOrUpdateLine(m_ltaName, lta.time1, lta.price1, lta.time2, lta.price2, clrGreen);
+        }
+        else
+        {
+            ObjectDelete(m_chartID, m_ltaName);
+        }
+
+        if(trendLines.IsLTBValid())
+        {
+            TrendLine ltb = trendLines.GetLTB();
+            CreateOrUpdateLine(m_ltbName, ltb.time1, ltb.price1, ltb.time2, ltb.price2, clrRed);
+        }
+        else
+        {
+            ObjectDelete(m_chartID, m_ltbName);
+        }
+    }
+
+    // Desenhar/atualizar níveis de suporte e resistência
+    void UpdateSupportResistance(const CSupportResistance &sr)
+    {
+        RemoveSRObjects();
+
+        SR_Level levels[];
+        sr.GetAllLevels(levels);
+        for(int i = 0; i < ArraySize(levels); i++)
+        {
+            SR_Level level = levels[i];
+            string name   = m_srPrefix + IntegerToString(i);
+            color  clr    = level.isSupport ? clrDodgerBlue : clrTomato;
+            CreateOrUpdateHLine(name, level.price, clr);
+        }
+    }
+
+private:
+    // Criar ou atualizar linha de tendência
+    void CreateOrUpdateLine(string name, datetime t1, double p1, datetime t2, double p2, color clr)
+    {
+        if(ObjectFind(m_chartID, name) < 0)
+        {
+            ObjectCreate(m_chartID, name, OBJ_TREND, 0, t1, p1, t2, p2);
+            ObjectSetInteger(m_chartID, name, OBJPROP_RAY_RIGHT, false);
+            ObjectSetInteger(m_chartID, name, OBJPROP_WIDTH, 2);
+        }
+        else
+        {
+            ObjectMove(m_chartID, name, 0, t1, p1);
+            ObjectMove(m_chartID, name, 1, t2, p2);
+        }
+        ObjectSetInteger(m_chartID, name, OBJPROP_COLOR, clr);
+    }
+
+    // Criar ou atualizar linha horizontal
+    void CreateOrUpdateHLine(string name, double price, color clr)
+    {
+        datetime now = TimeCurrent();
+        if(ObjectFind(m_chartID, name) < 0)
+        {
+            ObjectCreate(m_chartID, name, OBJ_HLINE, 0, now, price);
+            ObjectSetInteger(m_chartID, name, OBJPROP_WIDTH, 1);
+        }
+        else
+        {
+            ObjectSetDouble(m_chartID, name, OBJPROP_PRICE, price);
+        }
+        ObjectSetInteger(m_chartID, name, OBJPROP_COLOR, clr);
+    }
+
+    // Remover linhas SR existentes
+    void RemoveSRObjects()
+    {
+        for(int i = 0;; i++)
+        {
+            string name = m_srPrefix + IntegerToString(i);
+            if(ObjectFind(m_chartID, name) < 0)
+                break;
+            ObjectDelete(m_chartID, name);
+        }
+    }
+};
+
+#endif // VALIDATION_VISUALIZER_H
+


### PR DESCRIPTION
## Summary
- draw trendline, support and resistance levels during validation
- wire visualizer into trendline and SR classes
- show visualizer usage in `PriceActionTest.mq5`

## Testing
- `pytest` *(fails: no tests collected)*

------
https://chatgpt.com/codex/tasks/task_e_68586ae2d03083209e33238089756ead